### PR TITLE
[Feat] 공통 응답 및 양식 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,12 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	// lombok
 	implementation 'org.projectlombok:lombok'
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
+
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/likelion/innerjoin/common/entity/DataEntity.java
+++ b/src/main/java/com/likelion/innerjoin/common/entity/DataEntity.java
@@ -1,0 +1,30 @@
+package com.likelion.innerjoin.common.entity;
+
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+
+/**
+ * 모든 data entity가 상속해야하는 공통 entity
+ */
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public class DataEntity {
+    @CreatedDate
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/likelion/innerjoin/common/exception/ErrorCode.java
+++ b/src/main/java/com/likelion/innerjoin/common/exception/ErrorCode.java
@@ -1,0 +1,35 @@
+package com.likelion.innerjoin.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+
+/**
+ * 모든 error code 통합 enum class
+ * <p>
+ * 생기는 모든 특수한 error code에 대하여 새로운 enum을 생성하여 사용합니다.
+ * 예시)
+ * INVALID_VERIFICATION_TOKEN_ERROR(false, HttpStatus.BAD_REQUEST.value(), "인증 정보가 잘못되었거나 인증 시간이 초과되었습니다."),
+ */
+@Getter
+public enum ErrorCode {
+    //success
+    SUCCESS(true, HttpStatus.OK.value(), "요청에 성공했습니다."),
+
+    //valid
+    VALID_ERROR(false, HttpStatus.BAD_REQUEST.value(), "형식이 잘못되었습니다."),
+
+    //error
+    INTERNAL_SERVER_ERROR(false,HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버 내부에서 문제가 발생했습니다.")
+    ;
+
+    private final Boolean isSuccess;
+    private final int code;
+    private final String message;
+
+    ErrorCode(Boolean isSuccess, int code, String message) {
+        this.isSuccess = isSuccess;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/likelion/innerjoin/common/response/CommonResponse.java
+++ b/src/main/java/com/likelion/innerjoin/common/response/CommonResponse.java
@@ -1,0 +1,45 @@
+package com.likelion.innerjoin.common.response;
+
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.likelion.innerjoin.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * API 공통 응답을 위한 class
+ * @param <T> result에 들어갈 dto class
+ */
+@Getter
+@Setter
+public class CommonResponse<T> {
+
+    private Boolean isSuccess;
+    private int code;
+    private String message;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T result;
+
+    //성공시
+    public CommonResponse(T result) {
+        this.isSuccess = ErrorCode.SUCCESS.getIsSuccess();
+        this.code = ErrorCode.SUCCESS.getCode();
+        this.message = ErrorCode.SUCCESS.getMessage();
+        this.result = result;
+    }
+
+    // 오류 발생 (result 없음)
+    public CommonResponse(ErrorCode errorCode) {
+        this.isSuccess = ErrorCode.SUCCESS.getIsSuccess();
+        this.code = errorCode.getCode();
+        this.message = errorCode.getMessage();
+    }
+
+    // 오류 발생
+    public CommonResponse(ErrorCode errorCode, T result) {
+        this.isSuccess = ErrorCode.SUCCESS.getIsSuccess();
+        this.code = errorCode.getCode();
+        this.message = errorCode.getMessage();
+        this.result = result;
+    }
+}


### PR DESCRIPTION
## 🎯 이슈 번호

#4 [Feature] 공통 응답 및 entity 양식 추가

## 💡 작업 내용

- [x]  ErrorCode class 추가
- [x] 공통 DataEntity 추가
- [x] CommonResponse 추가

## 💡 자세한 설명

공통으로 상속할 DataEntity 추가
공통 응답 양식 추가
ErrorCode 통합 문서 추가

앞으로 생성되는 모든 entity에 대해 DataEntity를 상속해주면 자동으로 생성 일자 및 수정일자가 붙습니다.
ErrorCode에 상황별로 Enum이름을 지정하고 실패여부, code, message를 작성하여 사용하면됩니다.
Controller단에서 응답시 CommonResponse를 생성 후 return 하면 공통양식이 적용됩니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [ ] Reviewers, Labels, Projects를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
