### PR TITLE
[Feat] applicant 로그인 api 추가

### DIFF
--- a/src/main/java/com/likelion/innerjoin/common/exception/ErrorCode.java
+++ b/src/main/java/com/likelion/innerjoin/common/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
 
     //valid
     VALID_ERROR(false, HttpStatus.BAD_REQUEST.value(), "형식이 잘못되었습니다."),
+    APPLICANT_NOT_FOUNT(false, HttpStatus.UNAUTHORIZED.value(), "이메일 또는 비밀번호가 잘못되었습니다"),
 
     //error
     INTERNAL_SERVER_ERROR(false,HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버 내부에서 문제가 발생했습니다.")

--- a/src/main/java/com/likelion/innerjoin/common/response/CommonResponse.java
+++ b/src/main/java/com/likelion/innerjoin/common/response/CommonResponse.java
@@ -30,14 +30,14 @@ public class CommonResponse<T> {
 
     // 오류 발생 (result 없음)
     public CommonResponse(ErrorCode errorCode) {
-        this.isSuccess = ErrorCode.SUCCESS.getIsSuccess();
+        this.isSuccess = errorCode.getIsSuccess();
         this.code = errorCode.getCode();
         this.message = errorCode.getMessage();
     }
 
     // 오류 발생
     public CommonResponse(ErrorCode errorCode, T result) {
-        this.isSuccess = ErrorCode.SUCCESS.getIsSuccess();
+        this.isSuccess = errorCode.getIsSuccess();
         this.code = errorCode.getCode();
         this.message = errorCode.getMessage();
         this.result = result;

--- a/src/main/java/com/likelion/innerjoin/user/controller/LoginController.java
+++ b/src/main/java/com/likelion/innerjoin/user/controller/LoginController.java
@@ -1,0 +1,27 @@
+package com.likelion.innerjoin.user.controller;
+
+
+import com.likelion.innerjoin.common.response.CommonResponse;
+import com.likelion.innerjoin.user.model.dto.request.LoginRequestDto;
+import com.likelion.innerjoin.user.model.dto.response.LoginResponseDto;
+import com.likelion.innerjoin.user.service.LoginService;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/user")
+@RequiredArgsConstructor
+@Slf4j
+public class LoginController {
+    private final LoginService loginService;
+
+    @PostMapping("/login")
+    public CommonResponse<LoginResponseDto> login(@RequestBody LoginRequestDto loginRequestDto, HttpSession session) {
+        return new CommonResponse<>(loginService.login(loginRequestDto, session));
+    }
+}

--- a/src/main/java/com/likelion/innerjoin/user/exception/ApplicantNotFoundException.java
+++ b/src/main/java/com/likelion/innerjoin/user/exception/ApplicantNotFoundException.java
@@ -1,0 +1,10 @@
+package com.likelion.innerjoin.user.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ApplicantNotFoundException extends RuntimeException {
+    private String message;
+}

--- a/src/main/java/com/likelion/innerjoin/user/exception/LoginExceptionHandler.java
+++ b/src/main/java/com/likelion/innerjoin/user/exception/LoginExceptionHandler.java
@@ -1,0 +1,22 @@
+package com.likelion.innerjoin.user.exception;
+
+import com.likelion.innerjoin.common.exception.ErrorCode;
+import com.likelion.innerjoin.common.response.CommonResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class LoginExceptionHandler {
+    @ExceptionHandler(ApplicantNotFoundException.class)
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    public CommonResponse<?> applicantNotFound(ApplicantNotFoundException e, HttpServletRequest request) {
+        log.warn("APPLICANT-001> 요청 URI: " + request.getRequestURI() + ", 에러 메세지: " + e.getMessage());
+        return new CommonResponse<>(ErrorCode.APPLICANT_NOT_FOUNT);
+    }
+
+}

--- a/src/main/java/com/likelion/innerjoin/user/model/dto/request/LoginRequestDto.java
+++ b/src/main/java/com/likelion/innerjoin/user/model/dto/request/LoginRequestDto.java
@@ -1,0 +1,14 @@
+package com.likelion.innerjoin.user.model.dto.request;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginRequestDto {
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/likelion/innerjoin/user/model/dto/response/LoginResponseDto.java
+++ b/src/main/java/com/likelion/innerjoin/user/model/dto/response/LoginResponseDto.java
@@ -1,0 +1,17 @@
+package com.likelion.innerjoin.user.model.dto.response;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginResponseDto {
+    String studentNumber;
+    String email;
+    String name;
+}

--- a/src/main/java/com/likelion/innerjoin/user/repository/ApplicantRepository.java
+++ b/src/main/java/com/likelion/innerjoin/user/repository/ApplicantRepository.java
@@ -1,0 +1,8 @@
+package com.likelion.innerjoin.user.repository;
+
+import com.likelion.innerjoin.user.model.entity.Applicant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
+    Applicant findByEmailAndPassword(String email, String password);
+}

--- a/src/main/java/com/likelion/innerjoin/user/service/LoginService.java
+++ b/src/main/java/com/likelion/innerjoin/user/service/LoginService.java
@@ -1,0 +1,37 @@
+package com.likelion.innerjoin.user.service;
+
+
+import com.likelion.innerjoin.user.exception.ApplicantNotFoundException;
+import com.likelion.innerjoin.user.model.dto.request.LoginRequestDto;
+import com.likelion.innerjoin.user.model.dto.response.LoginResponseDto;
+import com.likelion.innerjoin.user.model.entity.Applicant;
+import com.likelion.innerjoin.user.repository.ApplicantRepository;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.NoSuchElementException;
+
+@Service
+@RequiredArgsConstructor
+public class LoginService {
+    public final ApplicantRepository applicantRepository;
+
+    public LoginResponseDto login(LoginRequestDto loginRequestDto, HttpSession session) {
+        try{
+            Applicant applicant =
+                    applicantRepository.findByEmailAndPassword(
+                            loginRequestDto.getEmail(),
+                            loginRequestDto.getPassword()
+                    );
+
+            if(applicant == null) {throw new ApplicantNotFoundException("아이디나 비밀번호가 잘못되었습니다.");}
+
+            session.setAttribute("userId", applicant.getId());
+            session.setAttribute("role", "applicant");
+            return new LoginResponseDto(applicant.getStudentNumber(), applicant.getEmail(), applicant.getName());
+        }catch (NoSuchElementException e){
+            throw new ApplicantNotFoundException("아이디나 비밀번호가 잘못되었습니다.");
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,3 +16,7 @@ spring:
             hibernate:
                 default_batch_fetch_size: 500
                 format_sql: true
+server:
+    servlet:
+      session:
+          timeout: 30m


### PR DESCRIPTION
## 🎯 이슈 번호

## 💡 작업 내용

- [x] CommonResponse쪽 잘못된 isSuccess 참조 수정
- [x] applicant 로그인시 exception 추가 및 api 추가

## 💡 자세한 설명

로그인시 email과 password로 유저정보를 찾아 session에 해당 정보를 등록하고 유저정보 반환

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [ ] Reviewers, Labels, Projects를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [ ] 불필요한 코드는 제거했나요?
