### PR TITLE
Feat/11

### DIFF
--- a/src/main/java/com/likelion/innerjoin/common/controller/BlobController.java
+++ b/src/main/java/com/likelion/innerjoin/common/controller/BlobController.java
@@ -2,10 +2,7 @@ package com.likelion.innerjoin.common.controller;
 
 import com.likelion.innerjoin.common.service.BlobService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -27,5 +24,16 @@ public class BlobController {
         myBlobService.storeFile(file.getOriginalFilename(), file.getInputStream(), file.getSize());
 
         return file.getOriginalFilename() + " 파일이 성공적으로 업로드되었습니다!";
+    }
+
+    @DeleteMapping("/delete")
+    public String deleteFile(@RequestParam("filename") String filename) {
+        boolean isDeleted = myBlobService.deleteFile(filename);
+
+        if (isDeleted) {
+            return filename + " 파일이 성공적으로 삭제되었습니다.";
+        } else {
+            return filename + " 파일을 삭제할 수 없습니다. 파일이 존재하지 않을 수 있습니다.";
+        }
     }
 }

--- a/src/main/java/com/likelion/innerjoin/common/service/BlobService.java
+++ b/src/main/java/com/likelion/innerjoin/common/service/BlobService.java
@@ -33,4 +33,13 @@ public class BlobService {
         client.upload(content, length);
         return client.getBlobUrl();  // URL 반환
     }
+
+    public boolean deleteFile(String filename) {
+        BlobClient client = containerClient().getBlobClient(filename);
+        if (client.exists()) {
+            client.delete();
+            return true;
+        }
+        return false;
+    }
 }

--- a/src/main/java/com/likelion/innerjoin/post/controller/PostController.java
+++ b/src/main/java/com/likelion/innerjoin/post/controller/PostController.java
@@ -32,8 +32,8 @@ public class PostController {
             @ApiResponse(responseCode = "200", description = "홍보글 리스트 조회 성공"),
             @ApiResponse(responseCode = "404", description = "홍보글을 찾을 수 없습니다")
     })
-    public CommonResponse<List<PostListResponseDTO>> getPosts() {
-        List<PostListResponseDTO> response = postService.getAllPosts();
+    public CommonResponse<List<PostListResponseDTO>> getPosts(@RequestParam(value = "clubName", required = false) String clubName) {
+        List<PostListResponseDTO> response = postService.getAllPosts(clubName);
         return new CommonResponse<>(response);
     }
 

--- a/src/main/java/com/likelion/innerjoin/post/repository/PostImageRepository.java
+++ b/src/main/java/com/likelion/innerjoin/post/repository/PostImageRepository.java
@@ -4,6 +4,10 @@ import com.likelion.innerjoin.post.model.entity.Post;
 import com.likelion.innerjoin.post.model.entity.PostImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.awt.*;
+import java.util.List;
+
 public interface PostImageRepository extends JpaRepository<PostImage, Long> {
     void deleteByPost(Post post);
+    List<PostImage> findByPostId(Long postId);
 }

--- a/src/main/java/com/likelion/innerjoin/post/repository/PostRepository.java
+++ b/src/main/java/com/likelion/innerjoin/post/repository/PostRepository.java
@@ -2,9 +2,15 @@ package com.likelion.innerjoin.post.repository;
 
 import com.likelion.innerjoin.post.model.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findByClubName(String clubName);
+
+    @Query("SELECT p FROM Post p WHERE p.club.name LIKE %:clubName%")
+    List<Post> findByClubNameContaining(@Param("clubName") String clubName);
+
 }

--- a/src/main/java/com/likelion/innerjoin/post/repository/PostRepository.java
+++ b/src/main/java/com/likelion/innerjoin/post/repository/PostRepository.java
@@ -3,5 +3,8 @@ package com.likelion.innerjoin.post.repository;
 import com.likelion.innerjoin.post.model.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PostRepository extends JpaRepository<Post, Long> {
+    List<Post> findByClubName(String clubName);
 }

--- a/src/main/java/com/likelion/innerjoin/post/service/PostService.java
+++ b/src/main/java/com/likelion/innerjoin/post/service/PostService.java
@@ -43,9 +43,15 @@ public class PostService {
     private final ApplicationMapper applicationMapper;
 
 
-    // 모든 홍보글 조회
-    public List<PostListResponseDTO> getAllPosts() {
-        List<Post> posts = postRepository.findAll();
+    // 홍보글 조회
+    public List<PostListResponseDTO> getAllPosts(String clubName) {
+        List<Post> posts;
+
+        if (clubName != null && !clubName.isEmpty()) {
+            posts = postRepository.findByClubName(clubName); // 동아리 이름으로 검색
+        } else {
+            posts = postRepository.findAll(); // 전체 조회
+        }
 
         if (posts.isEmpty()) {
             throw new PostNotFoundException();
@@ -55,6 +61,7 @@ public class PostService {
                 .map(this::toPostResponseDTO)
                 .collect(Collectors.toList());
     }
+
 
     // Post 엔티티를 PostResponseDTO로 변환
     private PostListResponseDTO toPostResponseDTO(Post post) {

--- a/src/main/java/com/likelion/innerjoin/post/service/PostService.java
+++ b/src/main/java/com/likelion/innerjoin/post/service/PostService.java
@@ -48,7 +48,7 @@ public class PostService {
         List<Post> posts;
 
         if (clubName != null && !clubName.isEmpty()) {
-            posts = postRepository.findByClubName(clubName); // 동아리 이름으로 검색
+            posts = postRepository.findByClubNameContaining(clubName); // 동아리 이름으로 검색
         } else {
             posts = postRepository.findAll(); // 전체 조회
         }

--- a/src/main/java/com/likelion/innerjoin/post/service/PostService.java
+++ b/src/main/java/com/likelion/innerjoin/post/service/PostService.java
@@ -17,7 +17,6 @@ import com.likelion.innerjoin.post.repository.PostRepository;
 import com.likelion.innerjoin.post.repository.RecruitingRepository;
 import com.likelion.innerjoin.user.model.entity.Club;
 import com.likelion.innerjoin.user.model.entity.User;
-import com.likelion.innerjoin.user.repository.ClubRepository;
 import com.likelion.innerjoin.user.util.SessionVerifier;
 import jakarta.servlet.http.HttpSession;
 import jakarta.transaction.Transactional;
@@ -37,7 +36,6 @@ public class PostService {
 
     private final PostRepository postRepository;
     private final PostImageRepository postImageRepository;
-    private final ClubRepository clubRepository;
     private final FormRepository formRepository;
     private final RecruitingRepository recruitingRepository;
     private final BlobService blobService;


### PR DESCRIPTION
## 🎯 11

## 💡 작업 내용

- [x] 홍보글 리스트 조회 시 동아리 이름으로 검색하는 기능 추가

## 💡 자세한 설명

쿼리파라미터 clubName으로 동아리 이름을 입력하면, 해당 동아리의 홍보글만 나옵니다.
쿼리파라미터가 없는 경우 전체 홍보글을 조회합니다.

## ✅ 셀프 체크리스트

- [ ] PR 제목을 형식에 맞게 작성했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [ ] Reviewers, Labels, Projects를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [ ] 불필요한 코드는 제거했나요?
