### PR TITLE
Feat/홍보글 필터링 검색 기능 추가

### DIFF
--- a/src/main/java/com/likelion/innerjoin/common/exception/ErrorCode.java
+++ b/src/main/java/com/likelion/innerjoin/common/exception/ErrorCode.java
@@ -26,12 +26,13 @@ public enum ErrorCode {
     DUPLICATE_LOGIN_ID(false, HttpStatus.BAD_REQUEST.value(), "이미 존재하는 아이디입니다."),
     DUPLICATE_EMAIL(false,HttpStatus.BAD_REQUEST.value(), "이미 존재하는 이메일입니다."),
     //error
+    POST_NOT_FOUND(false, HttpStatus.NOT_FOUND.value(), "홍보글을 찾을 수 없습니다."),
     UNIV_CERT_API_ERROR(false, HttpStatus.INTERNAL_SERVER_ERROR.value(), "학교 인증 API 호출 중 오류가 발생했습니다."),
     INTERNAL_SERVER_ERROR(false,HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버 내부에서 문제가 발생했습니다."),
     RECRUITING_NOT_FOUND(false, HttpStatus.NOT_FOUND.value(), "모집 중 직무가 존재하지 않습니다."),
     APPLICATION_NOT_FOUND(false, HttpStatus.NOT_FOUND.value(), "지원 내역이 존재하지 않습니다."),
     QUESTION_NOT_FOUND(false, HttpStatus.NOT_FOUND.value(), "질문이 존재하지 않습니다."),
-    POST_NOT_FOUND(false, 404, "홍보글을 찾을 수 없습니다."),
+
     WRONG_SESSION_ERROR(false, HttpStatus.UNAUTHORIZED.value(), "세션값이 잘못되었습니다."),
     JSON_CONVERT_ERROR(false, HttpStatus.INTERNAL_SERVER_ERROR.value(), "JSON 변환중 오류가 발생하였습니다."),
     CLUB_NOT_FOUND(false, 404, "동아리를 찾을 수 없습니다."),

--- a/src/main/java/com/likelion/innerjoin/post/controller/PostController.java
+++ b/src/main/java/com/likelion/innerjoin/post/controller/PostController.java
@@ -36,9 +36,10 @@ public class PostController {
     public CommonResponse<List<PostListResponseDTO>> getPosts(
             @RequestParam(value = "clubName", required = false) String clubName,
             @RequestParam(value = "categoryId", required = false) Long categoryId,
-            @RequestParam(value = "recruitmentType", required = false) String recruitmentType
+            @RequestParam(value = "recruitmentType", required = false) String recruitmentType,
+            @RequestParam(value = "isRecruiting", required = false) Boolean isRecruiting
     ) {
-        return new CommonResponse<>(postService.getAllPosts(clubName, categoryId, recruitmentType));
+        return new CommonResponse<>(postService.getAllPosts(clubName, categoryId, recruitmentType, isRecruiting));
     }
 
 

--- a/src/main/java/com/likelion/innerjoin/post/controller/PostController.java
+++ b/src/main/java/com/likelion/innerjoin/post/controller/PostController.java
@@ -1,6 +1,7 @@
 package com.likelion.innerjoin.post.controller;
 
 import com.likelion.innerjoin.common.response.CommonResponse;
+import com.likelion.innerjoin.post.exception.PostNotFoundException;
 import com.likelion.innerjoin.post.model.dto.request.MeetingTimeRequestDTO;
 import com.likelion.innerjoin.post.model.dto.request.PostModifyRequestDTO;
 import com.likelion.innerjoin.post.model.dto.response.*;
@@ -32,9 +33,12 @@ public class PostController {
             @ApiResponse(responseCode = "200", description = "홍보글 리스트 조회 성공"),
             @ApiResponse(responseCode = "404", description = "홍보글을 찾을 수 없습니다")
     })
-    public CommonResponse<List<PostListResponseDTO>> getPosts(@RequestParam(value = "clubName", required = false) String clubName) {
-        List<PostListResponseDTO> response = postService.getAllPosts(clubName);
-        return new CommonResponse<>(response);
+    public CommonResponse<List<PostListResponseDTO>> getPosts(
+            @RequestParam(value = "clubName", required = false) String clubName,
+            @RequestParam(value = "categoryId", required = false) Long categoryId,
+            @RequestParam(value = "recruitmentType", required = false) String recruitmentType
+    ) {
+        return new CommonResponse<>(postService.getAllPosts(clubName, categoryId, recruitmentType));
     }
 
 

--- a/src/main/java/com/likelion/innerjoin/post/exception/ApplicationExceptionHandler.java
+++ b/src/main/java/com/likelion/innerjoin/post/exception/ApplicationExceptionHandler.java
@@ -34,12 +34,12 @@ public class ApplicationExceptionHandler {
         return new CommonResponse<>(ErrorCode.QUESTION_NOT_FOUND);
     }
 
-    @ExceptionHandler(PostNotFoundException.class)
-    @ResponseStatus(HttpStatus.NOT_FOUND)
-    public CommonResponse<?> postNotFound(QuestionNotFoundException e, HttpServletRequest request) {
-        log.warn("APPLICATION-004> 요청 URI: " + request.getRequestURI() + ", 에러 메세지: " + e.getMessage());
-        return new CommonResponse<>(ErrorCode.POST_NOT_FOUND);
-    }
+//    @ExceptionHandler(PostNotFoundException.class)
+//    @ResponseStatus(HttpStatus.NOT_FOUND)
+//    public CommonResponse<?> postNotFound(QuestionNotFoundException e, HttpServletRequest request) {
+//        log.warn("APPLICATION-004> 요청 URI: " + request.getRequestURI() + ", 에러 메세지: " + e.getMessage());
+//        return new CommonResponse<>(ErrorCode.POST_NOT_FOUND);
+//    }
 
     @ExceptionHandler(AlreadyAppliedException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/src/main/java/com/likelion/innerjoin/post/exception/InvalidRecruitmentTypeException.java
+++ b/src/main/java/com/likelion/innerjoin/post/exception/InvalidRecruitmentTypeException.java
@@ -1,0 +1,7 @@
+package com.likelion.innerjoin.post.exception;
+
+public class InvalidRecruitmentTypeException extends RuntimeException {
+    public InvalidRecruitmentTypeException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/likelion/innerjoin/post/exception/PostExceptionHandler.java
+++ b/src/main/java/com/likelion/innerjoin/post/exception/PostExceptionHandler.java
@@ -13,7 +13,7 @@ public class PostExceptionHandler {
     // PostNotFoundException 처리
     @ExceptionHandler(PostNotFoundException.class)
     public ResponseEntity<CommonResponse<Object>> handlePostNotFoundException(PostNotFoundException ex) {
-        CommonResponse<Object> response = new CommonResponse<>(ex.getErrorCode());
+        CommonResponse<Object> response = new CommonResponse<>(ErrorCode.POST_NOT_FOUND, ex.getMessage());
         return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
     }
 

--- a/src/main/java/com/likelion/innerjoin/post/exception/PostNotFoundException.java
+++ b/src/main/java/com/likelion/innerjoin/post/exception/PostNotFoundException.java
@@ -5,16 +5,14 @@ import lombok.Getter;
 
 @Getter
 public class PostNotFoundException extends RuntimeException {
-
     private final ErrorCode errorCode;
-
-    public PostNotFoundException() {
-        super(ErrorCode.POST_NOT_FOUND.getMessage());
-        this.errorCode = ErrorCode.POST_NOT_FOUND;
-    }
 
     public PostNotFoundException(String message) {
         super(message);
         this.errorCode = ErrorCode.POST_NOT_FOUND;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
     }
 }

--- a/src/main/java/com/likelion/innerjoin/post/repository/PostRepository.java
+++ b/src/main/java/com/likelion/innerjoin/post/repository/PostRepository.java
@@ -2,15 +2,11 @@ package com.likelion.innerjoin.post.repository;
 
 import com.likelion.innerjoin.post.model.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-public interface PostRepository extends JpaRepository<Post, Long> {
-    List<Post> findByClubName(String clubName);
-
-    @Query("SELECT p FROM Post p WHERE p.club.name LIKE %:clubName%")
-    List<Post> findByClubNameContaining(@Param("clubName") String clubName);
-
+public interface PostRepository extends JpaRepository<Post, Long>, JpaSpecificationExecutor<Post> {
 }

--- a/src/main/java/com/likelion/innerjoin/post/service/PostService.java
+++ b/src/main/java/com/likelion/innerjoin/post/service/PostService.java
@@ -47,10 +47,10 @@ public class PostService {
     private final ApplicationMapper applicationMapper;
 
 
-    public List<PostListResponseDTO> getAllPosts(String clubName, Long categoryId, String recruitmentType) {
+    public List<PostListResponseDTO> getAllPosts(String clubName, Long categoryId, String recruitmentType, Boolean isRecruiting) {
         List<Post> posts;
 
-        if ((clubName == null || clubName.isEmpty()) && categoryId == null && (recruitmentType == null || recruitmentType.isEmpty())) {
+        if ((clubName == null || clubName.isEmpty()) && categoryId == null && (recruitmentType == null || recruitmentType.isEmpty()) && isRecruiting == null) {
             posts = postRepository.findAll(); // 전체 조회
         } else {
             posts = postRepository.findAll((root, query, criteriaBuilder) -> {
@@ -76,6 +76,15 @@ public class PostService {
                     }
                 }
 
+                // endTime 필터 (isRecruiting이 true: 지원 가능한 게시물, false: 마감된 게시물)
+                if (isRecruiting != null) {
+                    if (isRecruiting) {
+                        predicates.add(criteriaBuilder.greaterThanOrEqualTo(root.get("endTime"), criteriaBuilder.currentTimestamp()));
+                    } else {
+                        predicates.add(criteriaBuilder.lessThan(root.get("endTime"), criteriaBuilder.currentTimestamp()));
+                    }
+                }
+
                 return criteriaBuilder.and(predicates.toArray(new jakarta.persistence.criteria.Predicate[0]));
             });
         }
@@ -89,6 +98,7 @@ public class PostService {
                 .map(this::toPostResponseDTO)
                 .collect(Collectors.toList());
     }
+
 
 
 


### PR DESCRIPTION
## 🎯 11

## 💡 작업 내용

- [x] 홍보글 필터링 검색 기능 추가

## 💡 자세한 설명

홍보글 리스트 조회 API에서, 동아리명, 카테고리Id, 모집유형(서류만, 서류면접), 지원가능여부(endTime이 지났는지 여부)를 쿼리파라미터로 받습니다.
위 조건들에 따라 홍보글을 필터링 검색할 수 잇습니다.

## 📢 리뷰 요구 사항 (선택)
PostNotFoundException Handler가 중복되는 문제가 있었습니다. 추후 확인이 필요해 보입니다.

