### PR TITLE
Fix: 면접시간 예약 관련 수정

### DIFF
--- a/src/main/java/com/likelion/innerjoin/post/controller/PostController.java
+++ b/src/main/java/com/likelion/innerjoin/post/controller/PostController.java
@@ -157,7 +157,7 @@ public class PostController {
     })
     public CommonResponse<String> createInterviewTimes(@RequestBody MeetingTimeRequestDTO request, HttpSession session) {
         meetingTimeService.createMeetingTimes(request.getRecruitingId(), request, session);
-        return new CommonResponse<>("면접 가능 시간이 성공적으로 생성되었습니다.");
+        return new CommonResponse<>("면접 가능 시간 리스트가 설정되었습니다. 예약 가능 시간이 설정되었습니다.");
     }
 
 

--- a/src/main/java/com/likelion/innerjoin/post/controller/PostController.java
+++ b/src/main/java/com/likelion/innerjoin/post/controller/PostController.java
@@ -148,7 +148,7 @@ public class PostController {
 
 
     @PostMapping("/interview-times")
-    @Operation(summary = "특정 recruiting의 면접 가능 시간 생성")
+    @Operation(summary = "특정 recruiting의 면접 가능 시간 생성, 예약 가능 시간 설정")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "면접 가능 시간 생성 성공"),
             @ApiResponse(responseCode = "401", description = "세션값이 잘못되었습니다"),
@@ -156,7 +156,7 @@ public class PostController {
             @ApiResponse(responseCode = "500", description = "서버 내부 오류")
     })
     public CommonResponse<String> createInterviewTimes(@RequestBody MeetingTimeRequestDTO request, HttpSession session) {
-        meetingTimeService.createMeetingTimes(request.getRecruitingId(), request.getMeetingTimes(), session);
+        meetingTimeService.createMeetingTimes(request.getRecruitingId(), request, session);
         return new CommonResponse<>("면접 가능 시간이 성공적으로 생성되었습니다.");
     }
 

--- a/src/main/java/com/likelion/innerjoin/post/controller/PostController.java
+++ b/src/main/java/com/likelion/innerjoin/post/controller/PostController.java
@@ -162,7 +162,7 @@ public class PostController {
 
 
     @GetMapping("/interview-times/{recruiting_id}")
-    @Operation(summary = "특정 recruiting의 면접 가능 시간 목록 조회")
+    @Operation(summary = "특정 recruiting의 정보 조회 (직무명, 면접가능시간, 예약시간 등)")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "면접 가능 시간 목록 조회 성공"),
             @ApiResponse(responseCode = "404", description = "해당 recruiting id를 찾을 수 없음"),

--- a/src/main/java/com/likelion/innerjoin/post/model/dto/request/MeetingTimeRequestDTO.java
+++ b/src/main/java/com/likelion/innerjoin/post/model/dto/request/MeetingTimeRequestDTO.java
@@ -9,6 +9,8 @@ import java.util.List;
 public class MeetingTimeRequestDTO {
     private Long recruitingId;
     private List<MeetingTimeDto> meetingTimes;
+    private LocalDateTime reservationStartTime;
+    private LocalDateTime reservationEndTime;
 
     @Data
     public static class MeetingTimeDto {

--- a/src/main/java/com/likelion/innerjoin/post/model/dto/response/MeetingTimeListResponseDTO.java
+++ b/src/main/java/com/likelion/innerjoin/post/model/dto/response/MeetingTimeListResponseDTO.java
@@ -1,13 +1,19 @@
 package com.likelion.innerjoin.post.model.dto.response;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Data
 @AllArgsConstructor
+@Builder
 public class MeetingTimeListResponseDTO {
     private Long recruitingId;
+    private String jobTitle;
+    private LocalDateTime reservationStartTime;
+    private LocalDateTime reservationEndTime;
     private List<MeetingTimeResponseDTO> meetingTimes;
 }

--- a/src/main/java/com/likelion/innerjoin/post/model/entity/Recruiting.java
+++ b/src/main/java/com/likelion/innerjoin/post/model/entity/Recruiting.java
@@ -1,5 +1,6 @@
 package com.likelion.innerjoin.post.model.entity;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.likelion.innerjoin.common.entity.DataEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -7,6 +8,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Entity
@@ -31,6 +33,14 @@ public class Recruiting extends DataEntity {
 
     @Column(name = "job_title")
     private String jobTitle;
+
+    @Column(name = "reservation_start_time")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime reservationStartTime;
+
+    @Column(name = "reservation_end_time")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime reservationEndTime;
 
     @OneToMany(mappedBy = "recruiting", orphanRemoval = true, cascade = CascadeType.ALL)
     private List<Application> application;

--- a/src/main/java/com/likelion/innerjoin/post/repository/MeetingTimeRepository.java
+++ b/src/main/java/com/likelion/innerjoin/post/repository/MeetingTimeRepository.java
@@ -8,4 +8,5 @@ import java.util.List;
 
 public interface MeetingTimeRepository extends JpaRepository<MeetingTime, Long> {
     List<MeetingTime> findByRecruiting(Recruiting recruiting);
+    List<MeetingTime> findByRecruitingId(Long recruitingId);
 }

--- a/src/main/java/com/likelion/innerjoin/post/service/ApplicationService.java
+++ b/src/main/java/com/likelion/innerjoin/post/service/ApplicationService.java
@@ -20,6 +20,7 @@ import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -252,6 +253,13 @@ public class ApplicationService {
             throw new AllowedNumExceededException("면접 허용 인원을 초과했습니다.");
         }
 
+        // 예약 종료 시간 확인
+        LocalDateTime reservationEndTime = meetingTime.getRecruiting().getReservationEndTime();
+        if (reservationEndTime != null && LocalDateTime.now().isAfter(reservationEndTime)) {
+            throw new IllegalStateException("면접 예약이 종료되었습니다.");
+        }
+
+        //면접 시간 설정
         application.setMeetingTime(meetingTime);
         applicationRepository.save(application);
 

--- a/src/main/java/com/likelion/innerjoin/post/service/MeetingTimeService.java
+++ b/src/main/java/com/likelion/innerjoin/post/service/MeetingTimeService.java
@@ -6,10 +6,7 @@ import com.likelion.innerjoin.post.exception.RecruitingNotFoundException;
 import com.likelion.innerjoin.post.exception.UnauthorizedException;
 import com.likelion.innerjoin.post.model.dto.response.MeetingTimeResponseDTO;
 import com.likelion.innerjoin.post.model.dto.response.MeetingTimeListResponseDTO;
-import com.likelion.innerjoin.post.model.entity.Application;
-import com.likelion.innerjoin.post.model.entity.MeetingTime;
-import com.likelion.innerjoin.post.model.entity.Recruiting;
-import com.likelion.innerjoin.post.model.entity.Post;
+import com.likelion.innerjoin.post.model.entity.*;
 import com.likelion.innerjoin.post.model.dto.request.MeetingTimeRequestDTO;
 import com.likelion.innerjoin.post.repository.MeetingTimeRepository;
 import com.likelion.innerjoin.post.repository.PostRepository;
@@ -48,6 +45,11 @@ public class MeetingTimeService {
 
         if (!post.getClub().getId().equals(checkClub(session).getId())) {
             throw new UnauthorizedException("홍보글의 club_id가 현재 유저의 club_id와 일치하지 않습니다.");
+        }
+
+        // 홍보글의 RecruitmentStatus 확인 (면접 시간이 이미 확정된 경우)
+        if (post.getRecruitmentStatus() == RecruitmentStatus.TIME_SET) {
+            throw new IllegalStateException("면접 시간이 이미 공개되어서(TIME_SET) 다시 설정할 수 없습니다.");
         }
 
         // 기존 MeetingTime 삭제

--- a/src/main/java/com/likelion/innerjoin/post/service/MeetingTimeService.java
+++ b/src/main/java/com/likelion/innerjoin/post/service/MeetingTimeService.java
@@ -88,7 +88,7 @@ public class MeetingTimeService {
         return club;
     }
 
-    //면접시간 정보 조회
+    // 특정 recruiting의 면접시간 정보 조회
     public CommonResponse<MeetingTimeListResponseDTO> getMeetingTimesByRecruitingId(Long recruitingId) {
         // recruiting 찾기
         Recruiting recruiting = recruitingRepository.findById(recruitingId)
@@ -121,7 +121,15 @@ public class MeetingTimeService {
                 })
                 .collect(Collectors.toList());
 
-        MeetingTimeListResponseDTO responseDto = new MeetingTimeListResponseDTO(recruitingId, meetingTimeDtos);
+        MeetingTimeListResponseDTO responseDto = new MeetingTimeListResponseDTO(
+                recruiting.getId(),
+                recruiting.getJobTitle(),
+                recruiting.getReservationStartTime(),
+                recruiting.getReservationEndTime(),
+                meetingTimeDtos
+        );
+
         return new CommonResponse<>(responseDto);
     }
+
 }

--- a/src/main/java/com/likelion/innerjoin/post/service/MeetingTimeService.java
+++ b/src/main/java/com/likelion/innerjoin/post/service/MeetingTimeService.java
@@ -47,6 +47,12 @@ public class MeetingTimeService {
             throw new UnauthorizedException("홍보글의 club_id가 현재 유저의 club_id와 일치하지 않습니다.");
         }
 
+        // 기존 MeetingTime 삭제
+        List<MeetingTime> existingMeetingTimes = meetingTimeRepository.findByRecruitingId(recruitingId);
+        if (!existingMeetingTimes.isEmpty()) {
+            meetingTimeRepository.deleteAll(existingMeetingTimes);
+        }
+
         // 요청DTO를 MeetingTime 엔티티로 변환
         List<MeetingTime> meetingTimes = meetingTimeDtos.stream()
                 .map(dto -> {


### PR DESCRIPTION
## 🎯 이슈 번호

## 💡 작업 내용

- [x] 면접가능시간 설정 시 기존 리스트 삭제 후 재저장하도록 수정
- [x] Recruiting 엔티티에 예약 시작/종료시간 추가 및 이에 따른 수정

## 💡 자세한 설명

1. 면접가능시간 리스트 설정 시, 기존 리스트가 존재하는 경우 삭제 후 재저장되도록 했습니다. 
단, 지원자들에게 이미 면접시간이 공개된 경우 (recruitmentStatus가 TIME_SET인 경우)에는 재설정할 수 없도록 했습니다.

2. Recruiting 엔티티에 `예약 시작시간`, `예약 종료시간` 필드를 추가했습니다.
2-1) 면접가능시간 리스트 설정 api에서 예약 시작/종료시간을 함께 설정합니다.
2-2) 특정 리크루팅의 면접시간 정보 조회 api (GET /posts/interview-times/{recruitingId})에서 예약 시작/종료시간도 함꼐 제공하도록 수정했습니다.
2-3) 면접시간 선택 시 (POST /application/interview-time), 예약 종료시간이 지났으면 예약하지 못하도록 구현했습니다.


## 📢 리뷰 요구 사항 (선택)
특정 리크루팅의 면접시간 정보 조회 api (GET /posts/interview-times/{recruitingId})를 제외하고, 예약시간 정보가 필요한 API가 더 있을까요?
