### PR TITLE
[Feat] sessionVerifier에 club 및 applicant 메서드 추가 및 recruiting과 club 엔티티 연결

### DIFF
--- a/src/main/java/com/likelion/innerjoin/post/controller/ApplicationController.java
+++ b/src/main/java/com/likelion/innerjoin/post/controller/ApplicationController.java
@@ -65,6 +65,11 @@ public class ApplicationController {
 
     @PutMapping("/{application_id}")
     @Operation(summary = "지원서 정보 수정용 api (동아리용)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공적인 응답"),
+            @ApiResponse(responseCode = "401", description = "권한이 없습니다."),
+            @ApiResponse(responseCode = "400", description = "허용 인원을 초과하였습니다.")
+    })
     public CommonResponse<ApplicationDto> updateApplication(
             @RequestBody ApplicationPutRequestDto applicationPutRequestDto,
             @PathVariable("application_id") Long applicationId,

--- a/src/main/java/com/likelion/innerjoin/post/model/entity/Recruiting.java
+++ b/src/main/java/com/likelion/innerjoin/post/model/entity/Recruiting.java
@@ -2,6 +2,7 @@ package com.likelion.innerjoin.post.model.entity;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.likelion.innerjoin.common.entity.DataEntity;
+import com.likelion.innerjoin.user.model.entity.Club;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -30,6 +31,10 @@ public class Recruiting extends DataEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name  = "post_id")
     private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "clud_id")
+    private Club club;
 
     @Column(name = "job_title")
     private String jobTitle;

--- a/src/main/java/com/likelion/innerjoin/post/repository/MeetingTimeRepository.java
+++ b/src/main/java/com/likelion/innerjoin/post/repository/MeetingTimeRepository.java
@@ -2,14 +2,23 @@ package com.likelion.innerjoin.post.repository;
 
 import com.likelion.innerjoin.post.model.entity.MeetingTime;
 import com.likelion.innerjoin.post.model.entity.Recruiting;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface MeetingTimeRepository extends JpaRepository<MeetingTime, Long> {
     List<MeetingTime> findByRecruiting(Recruiting recruiting);
-    List<MeetingTime> findByRecruitingId(Long recruitingId);
-    MeetingTime findByMeetingStartTimeAndRecruiting(LocalDateTime startTime, Recruiting recruiting);
-    MeetingTime findByMeetingStartTimeAndMeetingEndTimeAndRecruiting(LocalDateTime meetingStartTime, LocalDateTime meetingEndTime, Recruiting recruiting);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    List<MeetingTime> lockFindByRecruitingId(Long recruitingId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    MeetingTime lockFindByMeetingStartTimeAndRecruiting(LocalDateTime startTime, Recruiting recruiting);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<MeetingTime> selectMeetingTimeById(Long id);
 }

--- a/src/main/java/com/likelion/innerjoin/post/repository/MeetingTimeRepository.java
+++ b/src/main/java/com/likelion/innerjoin/post/repository/MeetingTimeRepository.java
@@ -14,11 +14,11 @@ public interface MeetingTimeRepository extends JpaRepository<MeetingTime, Long> 
     List<MeetingTime> findByRecruiting(Recruiting recruiting);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    List<MeetingTime> lockFindByRecruitingId(Long recruitingId);
+    List<MeetingTime> findByRecruitingId(Long recruitingId);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    MeetingTime lockFindByMeetingStartTimeAndRecruiting(LocalDateTime startTime, Recruiting recruiting);
+    MeetingTime findByMeetingStartTimeAndRecruiting(LocalDateTime startTime, Recruiting recruiting);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    Optional<MeetingTime> selectMeetingTimeById(Long id);
+    Optional<MeetingTime> findById(Long id);
 }

--- a/src/main/java/com/likelion/innerjoin/post/service/ApplicationService.java
+++ b/src/main/java/com/likelion/innerjoin/post/service/ApplicationService.java
@@ -138,7 +138,7 @@ public class ApplicationService {
         if(applicationPutRequestDto.getMeetingStartTime() == null){
             application.setMeetingTime(null);
         }else if(application.getMeetingTime() == null || !application.getMeetingTime().getMeetingStartTime().equals(applicationPutRequestDto.getMeetingStartTime())) {
-            MeetingTime meetingTime = meetingTimeRepository.findByMeetingStartTimeAndRecruiting(
+            MeetingTime meetingTime = meetingTimeRepository.lockFindByMeetingStartTimeAndRecruiting(
                     applicationPutRequestDto.getMeetingStartTime(),
                     application.getRecruiting()
             );
@@ -251,7 +251,7 @@ public class ApplicationService {
         }
 
         // 면접 시간 확인
-        MeetingTime meetingTime = meetingTimeRepository.findById(dto.getMeetingTimeId())
+        MeetingTime meetingTime = meetingTimeRepository.selectMeetingTimeById(dto.getMeetingTimeId())
                 .orElseThrow(() -> new MeetingTimeNotFound("면접시간이 존재하지 않습니다."));
         // 권한 확인
         if(!meetingTime.getRecruiting().equals(application.getRecruiting())){

--- a/src/main/java/com/likelion/innerjoin/post/service/ApplicationService.java
+++ b/src/main/java/com/likelion/innerjoin/post/service/ApplicationService.java
@@ -58,6 +58,7 @@ public class ApplicationService {
         application.setRecruiting(recruiting);
 
         Post post = recruiting.getPost();
+        // recruitment type에 따른 처리
         if(post.getRecruitmentType() == RecruitmentType.FORM_AND_MEETING){
             application.setFormResult(ResultType.PENDING);
             application.setMeetingResult(ResultType.PENDING);
@@ -102,7 +103,7 @@ public class ApplicationService {
             }
         }else {
             Club club = (Club) user;
-            if (!club.equals(application.getRecruiting().getPost().getClub())) {
+            if (!club.equals(application.getRecruiting().getClub())) {
                 throw new UnauthorizedException("권한이 없습니다.");
             }
         }
@@ -130,7 +131,7 @@ public class ApplicationService {
         Application application = applicationRepository.findById(applicationId)
                 .orElseThrow(() -> new ApplicationNotFoundException("id: " + applicationId + " 지원서가 존재하지 않습니다."));
 
-        if(!application.getRecruiting().getPost().getClub().equals(club) ) {
+        if(!application.getRecruiting().getClub().equals(club) ) {
             throw new UnauthorizedException("권한이 없습니다.");
         }
 
@@ -145,6 +146,7 @@ public class ApplicationService {
                 throw new MeetingTimeNotFound("면접시간이 존재하지 않습니다.");
             }
 
+            // todo : 허용 인원 처리 개선 필요. 동접자가 많지는 않으므로 locking으로 동시성 처리하기
             if(meetingTime.getApplicationList().size() >= meetingTime.getAllowedNum() && !meetingTime.getApplicationList().contains(application)){
                 throw new AllowedNumExceededException("허용 인원을 초과하였습니다.");
             }
@@ -165,7 +167,7 @@ public class ApplicationService {
         Application application = applicationRepository.findById(formScoreDto.getApplicationId())
                 .orElseThrow(() -> new ApplicationNotFoundException("지원서가 존재하지 않습니다."));
 
-        if(!application.getRecruiting().getPost().getClub().equals(club)) {
+        if(!application.getRecruiting().getClub().equals(club)) {
             throw new UnauthorizedException("권한이 없습니다.");
         }
 
@@ -191,9 +193,10 @@ public class ApplicationService {
     public ApplicationDto updateMeetingScore(MeetingScoreDto meetingScoreDto, HttpSession session) {
         Club club = sessionVerifier.getClub(session);
 
+        // 지원서 확인
         Application application = applicationRepository.findById(meetingScoreDto.getApplicationId())
                 .orElseThrow(() -> new ApplicationNotFoundException("지원서가 존재하지 않습니다."));
-
+        // 권한 확인
         if(!application.getRecruiting().getPost().getClub().equals(club)) {
             throw new UnauthorizedException("권한이 없습니다.");
         }
@@ -214,7 +217,7 @@ public class ApplicationService {
 
         List<Application> application = applicationRepository.findAllById(emailDto.getApplicationIdList());
 
-        // 해당 post에 대한 지원자 이메일인지 검증은 일단 스킵
+        // todo : 해당 post에 대한 지원자 이메일인지 검증 필요해보임
         List<String> emailList = new ArrayList<>();
         for(Application app : application){
             emailList.add(app.getApplicant().getEmail());
@@ -239,25 +242,31 @@ public class ApplicationService {
     @Transactional
     public MeetingTimeResponseDTO selectMeetingTime (MeetingTimeSelectionDto dto, HttpSession session){
         Applicant applicant = sessionVerifier.getApplicant(session);
+        // 지원서 id 확인
         Application application = applicationRepository.findById(dto.getApplicationId())
                 .orElseThrow(()-> new ApplicationNotFoundException("지원 이력이 없습니다."));
+        // 권한 확인
         if(!application.getApplicant().equals(applicant)){
             throw new UnauthorizedException("권한이 없습니다.");
         }
 
+        // 면접 시간 확인
         MeetingTime meetingTime = meetingTimeRepository.findById(dto.getMeetingTimeId())
                 .orElseThrow(() -> new MeetingTimeNotFound("면접시간이 존재하지 않습니다."));
+        // 권한 확인
         if(!meetingTime.getRecruiting().equals(application.getRecruiting())){
             throw new UnauthorizedException("권한이 없습니다.");
-        }
-        if(meetingTime.getAllowedNum()<= meetingTime.getApplicationList().size()){
-            throw new AllowedNumExceededException("면접 허용 인원을 초과했습니다.");
         }
 
         // 예약 종료 시간 확인
         LocalDateTime reservationEndTime = meetingTime.getRecruiting().getReservationEndTime();
         if (reservationEndTime != null && LocalDateTime.now().isAfter(reservationEndTime)) {
             throw new IllegalStateException("면접 예약이 종료되었습니다.");
+        }
+
+        // todo: 면접 시간 선택시 동시성 처리
+        if(meetingTime.getAllowedNum()<= meetingTime.getApplicationList().size()) {
+            throw new AllowedNumExceededException("면접 허용 인원을 초과했습니다.");
         }
 
         //면접 시간 설정

--- a/src/main/java/com/likelion/innerjoin/post/service/ApplicationService.java
+++ b/src/main/java/com/likelion/innerjoin/post/service/ApplicationService.java
@@ -146,7 +146,6 @@ public class ApplicationService {
                 throw new MeetingTimeNotFound("면접시간이 존재하지 않습니다.");
             }
 
-            // todo : 허용 인원 처리 개선 필요. 동접자가 많지는 않으므로 locking으로 동시성 처리하기
             if(meetingTime.getApplicationList().size() >= meetingTime.getAllowedNum() && !meetingTime.getApplicationList().contains(application)){
                 throw new AllowedNumExceededException("허용 인원을 초과하였습니다.");
             }
@@ -264,7 +263,6 @@ public class ApplicationService {
             throw new IllegalStateException("면접 예약이 종료되었습니다.");
         }
 
-        // todo: 면접 시간 선택시 동시성 처리
         if(meetingTime.getAllowedNum()<= meetingTime.getApplicationList().size()) {
             throw new AllowedNumExceededException("면접 허용 인원을 초과했습니다.");
         }

--- a/src/main/java/com/likelion/innerjoin/post/service/ApplicationService.java
+++ b/src/main/java/com/likelion/innerjoin/post/service/ApplicationService.java
@@ -138,7 +138,7 @@ public class ApplicationService {
         if(applicationPutRequestDto.getMeetingStartTime() == null){
             application.setMeetingTime(null);
         }else if(application.getMeetingTime() == null || !application.getMeetingTime().getMeetingStartTime().equals(applicationPutRequestDto.getMeetingStartTime())) {
-            MeetingTime meetingTime = meetingTimeRepository.lockFindByMeetingStartTimeAndRecruiting(
+            MeetingTime meetingTime = meetingTimeRepository.findByMeetingStartTimeAndRecruiting(
                     applicationPutRequestDto.getMeetingStartTime(),
                     application.getRecruiting()
             );
@@ -250,7 +250,7 @@ public class ApplicationService {
         }
 
         // 면접 시간 확인
-        MeetingTime meetingTime = meetingTimeRepository.selectMeetingTimeById(dto.getMeetingTimeId())
+        MeetingTime meetingTime = meetingTimeRepository.findById(dto.getMeetingTimeId())
                 .orElseThrow(() -> new MeetingTimeNotFound("면접시간이 존재하지 않습니다."));
         // 권한 확인
         if(!meetingTime.getRecruiting().equals(application.getRecruiting())){

--- a/src/main/java/com/likelion/innerjoin/post/service/ApplicationService.java
+++ b/src/main/java/com/likelion/innerjoin/post/service/ApplicationService.java
@@ -43,7 +43,7 @@ public class ApplicationService {
 
     @Transactional
     public Application postApplication (ApplicationRequestDto applicationRequestDto, HttpSession session) {
-        Applicant applicant = checkApplicant(session);
+        Applicant applicant = sessionVerifier.getApplicant(session);
         Recruiting recruiting = recruitingRepository.findById(applicationRequestDto.getRecruitingId())
                 .orElseThrow(() ->new RecruitingNotFoundException("모집중 직무가 존재하지 않습니다."));
 
@@ -111,7 +111,7 @@ public class ApplicationService {
     }
 
     public List<ApplicationDto> getApplicationList(HttpSession session) {
-        Applicant applicant = checkApplicant(session);
+        Applicant applicant = sessionVerifier.getApplicant(session);
 
         List<Application> applicationList = applicationRepository.findByApplicant(applicant);
 
@@ -125,7 +125,7 @@ public class ApplicationService {
             ApplicationPutRequestDto applicationPutRequestDto,
             Long applicationId,
             HttpSession session){
-        Club club = checkClub(session);
+        Club club = sessionVerifier.getClub(session);
 
         Application application = applicationRepository.findById(applicationId)
                 .orElseThrow(() -> new ApplicationNotFoundException("id: " + applicationId + " 지원서가 존재하지 않습니다."));
@@ -160,7 +160,7 @@ public class ApplicationService {
 
     @Transactional
     public ApplicationDto updateFormScore(FormScoreDto formScoreDto, HttpSession session) {
-        Club club = checkClub(session);
+        Club club = sessionVerifier.getClub(session);
 
         Application application = applicationRepository.findById(formScoreDto.getApplicationId())
                 .orElseThrow(() -> new ApplicationNotFoundException("지원서가 존재하지 않습니다."));
@@ -189,7 +189,7 @@ public class ApplicationService {
 
     @Transactional
     public ApplicationDto updateMeetingScore(MeetingScoreDto meetingScoreDto, HttpSession session) {
-        Club club = checkClub(session);
+        Club club = sessionVerifier.getClub(session);
 
         Application application = applicationRepository.findById(meetingScoreDto.getApplicationId())
                 .orElseThrow(() -> new ApplicationNotFoundException("지원서가 존재하지 않습니다."));
@@ -205,7 +205,7 @@ public class ApplicationService {
 
     public ErrorCode sendEmail(EmailDto emailDto, HttpSession session) {
 
-        Club club = checkClub(session);
+        Club club = sessionVerifier.getClub(session);
         Post post = postRepository.findById(emailDto.getPostId())
                 .orElseThrow(() -> new PostNotFoundException("권한이 없습니다."));
         if(!post.getClub().equals(club)) {
@@ -238,7 +238,7 @@ public class ApplicationService {
      */
     @Transactional
     public MeetingTimeResponseDTO selectMeetingTime (MeetingTimeSelectionDto dto, HttpSession session){
-        Applicant applicant = checkApplicant(session);
+        Applicant applicant = sessionVerifier.getApplicant(session);
         Application application = applicationRepository.findById(dto.getApplicationId())
                 .orElseThrow(()-> new ApplicationNotFoundException("지원 이력이 없습니다."));
         if(!application.getApplicant().equals(applicant)){
@@ -272,21 +272,5 @@ public class ApplicationService {
                 meetingTime.getMeetingStartTime(),
                 meetingTime.getMeetingEndTime()
         );
-    }
-
-    Applicant checkApplicant (HttpSession session) {
-        User user = sessionVerifier.verifySession(session);
-        if(!(user instanceof Applicant applicant)) {
-            throw new UnauthorizedException("권한이 없습니다.");
-        }
-        return applicant;
-    }
-
-    Club checkClub (HttpSession session) {
-        User user = sessionVerifier.verifySession(session);
-        if(!(user instanceof Club club)) {
-            throw new UnauthorizedException("권한이 없습니다.");
-        }
-        return club;
     }
 }

--- a/src/main/java/com/likelion/innerjoin/post/service/MeetingTimeService.java
+++ b/src/main/java/com/likelion/innerjoin/post/service/MeetingTimeService.java
@@ -53,7 +53,7 @@ public class MeetingTimeService {
         }
 
         // 기존 MeetingTime 삭제
-        List<MeetingTime> existingMeetingTimes = meetingTimeRepository.lockFindByRecruitingId(recruitingId);
+        List<MeetingTime> existingMeetingTimes = meetingTimeRepository.findByRecruitingId(recruitingId);
         if (!existingMeetingTimes.isEmpty()) {
             meetingTimeRepository.deleteAll(existingMeetingTimes);
         }

--- a/src/main/java/com/likelion/innerjoin/post/service/MeetingTimeService.java
+++ b/src/main/java/com/likelion/innerjoin/post/service/MeetingTimeService.java
@@ -53,7 +53,7 @@ public class MeetingTimeService {
         }
 
         // 기존 MeetingTime 삭제
-        List<MeetingTime> existingMeetingTimes = meetingTimeRepository.findByRecruitingId(recruitingId);
+        List<MeetingTime> existingMeetingTimes = meetingTimeRepository.lockFindByRecruitingId(recruitingId);
         if (!existingMeetingTimes.isEmpty()) {
             meetingTimeRepository.deleteAll(existingMeetingTimes);
         }

--- a/src/main/java/com/likelion/innerjoin/post/service/PostService.java
+++ b/src/main/java/com/likelion/innerjoin/post/service/PostService.java
@@ -240,6 +240,7 @@ public class PostService {
                 Recruiting recruiting = Recruiting.builder()
                         .form(form)
                         .post(post)
+                        .club(club)
                         .jobTitle(recruitingRequest.getJobTitle())
                         .build();
 

--- a/src/main/java/com/likelion/innerjoin/user/util/SessionVerifier.java
+++ b/src/main/java/com/likelion/innerjoin/user/util/SessionVerifier.java
@@ -1,6 +1,8 @@
 package com.likelion.innerjoin.user.util;
 
 import com.likelion.innerjoin.post.exception.UnauthorizedException;
+import com.likelion.innerjoin.user.model.entity.Applicant;
+import com.likelion.innerjoin.user.model.entity.Club;
 import com.likelion.innerjoin.user.model.entity.User;
 import com.likelion.innerjoin.user.repository.ApplicantRepository;
 import com.likelion.innerjoin.user.repository.ClubRepository;
@@ -14,6 +16,7 @@ public class SessionVerifier {
     private final ClubRepository clubRepository;
     private final ApplicantRepository applicantRepository;
 
+    @Deprecated
     public User verifySession(HttpSession session) {
         if( session == null ){
             throw new UnauthorizedException("잘못된 접근입니다.");
@@ -35,6 +38,54 @@ public class SessionVerifier {
             return clubRepository.findById(userId).orElseThrow(() -> new UnauthorizedException("잘못된 유저입니다."));
         }else if ( role.equals("applicant") ){
             return applicantRepository.findById(userId).orElseThrow(() -> new UnauthorizedException("잘못된 유저입니다."));
+        }else {
+            throw new UnauthorizedException("잘못된 유저입니다.");
+        }
+    }
+
+    public Applicant getApplicant(HttpSession session) {
+        if( session == null ){
+            throw new UnauthorizedException("잘못된 접근입니다.");
+        }
+
+        if( session.getAttribute("userId") == null || session.getAttribute("role") == null ){
+            throw new UnauthorizedException("잘못된 접근입니다.");
+        }
+
+        Long userId = (Long) session.getAttribute("userId");
+
+        String role = (String) session.getAttribute("role");
+
+        if( userId == null ){
+            throw new UnauthorizedException("잘못된 유저입니다.");
+        }
+
+        if ( role.equals("applicant") ){
+            return applicantRepository.findById(userId).orElseThrow(() -> new UnauthorizedException("잘못된 유저입니다."));
+        }else {
+            throw new UnauthorizedException("잘못된 유저입니다.");
+        }
+    }
+
+    public Club getClub(HttpSession session) {
+        if( session == null ){
+            throw new UnauthorizedException("잘못된 접근입니다.");
+        }
+
+        if( session.getAttribute("userId") == null || session.getAttribute("role") == null ){
+            throw new UnauthorizedException("잘못된 접근입니다.");
+        }
+
+        Long userId = (Long) session.getAttribute("userId");
+
+        String role = (String) session.getAttribute("role");
+
+        if( userId == null ){
+            throw new UnauthorizedException("잘못된 유저입니다.");
+        }
+
+        if( role.equals("club") ){
+            return clubRepository.findById(userId).orElseThrow(() -> new UnauthorizedException("잘못된 유저입니다."));
         }else {
             throw new UnauthorizedException("잘못된 유저입니다.");
         }


### PR DESCRIPTION
## 🎯 이슈 번호

## 💡 작업 내용

- [x] sessionVerifier에 club 및 applicant 메서드 추가
- [x] recruiting과 club 엔티티 연결
- [x] jpa lock을 이용하여 동시성 문제 해결 
- [ ] 몇가지 개선사항 todo 주석으로 정리

## 💡 자세한 설명

session verifier에 club과 applicant 객체를 바로 얻을 수 있는 메서드 추가 ( reflection api를 안쓰기때문에 빠름 )
recruiting entity에 club 연결
면접 시간 선택 시 동시성 문제를 jpa lock을 이용하여 처리
개선사항 todo 추가

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)


## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
